### PR TITLE
Add a settings option to allow MediaFile translations to be skipped

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -98,6 +98,10 @@ pages.
 Prevent admin page deletion for pages which have been allocated a Template with
 ``singleton=True``.
 
+``FEINCMS_MEDIAFILE_TRANSLATIONS``: Defaults to ``True``. Set to ``False`` if
+you want FeinCMS to not translate ``MediaFile`` names, and instead just use the
+filename directly.
+
 
 Various settings
 ================

--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -136,3 +136,10 @@ FEINCMS_SINGLETON_TEMPLATE_DELETION_ALLOWED = getattr(
 FEINCMS_FRONTEND_LANGUAGES = getattr(settings, "FEINCMS_FRONTEND_LANGUAGES", None)
 
 # ------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
+#: Attempt to get translations of MediaFile objects. If `False`, FeinCMS will
+#: instead just output the file name.
+FEINCMS_MEDIAFILE_TRANSLATIONS = getattr(settings, "FEINCMS_MEDIAFILE_TRANSLATIONS", True)
+
+# ------------------------------------------------------------------------

--- a/feincms/module/medialibrary/models.py
+++ b/feincms/module/medialibrary/models.py
@@ -157,17 +157,19 @@ class MediaFileBase(models.Model, ExtensionsMixin, TranslatedObjectMixin):
     def __str__(self):
         trans = None
 
-        try:
-            trans = self.translation
-        except models.ObjectDoesNotExist:
-            pass
-        except AttributeError:
-            pass
+        if settings.FEINCMS_MEDIAFILE_TRANSLATIONS:
+            try:
+                trans = self.translation
+            except models.ObjectDoesNotExist:
+                pass
+            except AttributeError:
+                pass
 
         if trans:
             trans = "%s" % trans
             if trans.strip():
                 return trans
+
         return os.path.basename(self.file.name)
 
     def get_absolute_url(self):


### PR DESCRIPTION
This flag should hopefully resolve https://github.com/feincms/feincms/issues/675

To be clear, this isn't really a _solution_ to the problem, basically the root of the issue here is that the `translations` lazy-eval property is largely inefficient (perhaps just in certain cases)

But at the same time, as a feature I think it makes sense regardless - and it fortunately sidesteps the root issue very nicely.